### PR TITLE
Better caching middleware

### DIFF
--- a/src/redis/cache.middleware.ts
+++ b/src/redis/cache.middleware.ts
@@ -1,0 +1,52 @@
+import { Injectable, Logger, NestMiddleware } from '@nestjs/common';
+import { Request, Response, NextFunction } from 'express';
+import { cacheKeyCreator, parseQueryParams } from '../util';
+import { PaginationParams } from '../../types';
+import { RedisService } from './redis.service';
+
+/**
+ * does the following:
+ * 1. parses the query
+ * 2. creates the cache key
+ * 3. checks for a cache hit
+ * 4. if cache hit, return data
+ * 5. else, add 'query' & 'cacheKey' to req object & next()
+ */
+@Injectable()
+export class CacheMiddleware implements NestMiddleware {
+  private readonly logger;
+
+  constructor(private cache: RedisService) {
+    this.logger = new Logger(CacheMiddleware.name);
+  }
+
+  async use(req: Request, res: Response, next: NextFunction) {
+    // this.logger.log(`middleware: ${req.path}`);
+
+    this.logger.log(req.params['0']);
+
+    const params: PaginationParams = parseQueryParams(
+      req.query as unknown as string,
+    );
+
+    // this.logger.log(params);
+
+    const cacheKey = cacheKeyCreator(req.params['0'], params);
+
+    this.logger.log(`cacheKey: ${cacheKey}`);
+
+    // get the data from the cache if exists
+    const data = await this.cache.get(cacheKey);
+
+    if (data) {
+      this.logger.log('Cache HIT!');
+      // this.logger.log(data);
+      return res.json(data);
+    }
+
+    this.logger.log('Cache MISS!');
+    req.body['params'] = params;
+    req.body['cacheKey'] = cacheKey;
+    next();
+  }
+}

--- a/src/redis/redis.module.ts
+++ b/src/redis/redis.module.ts
@@ -2,6 +2,7 @@ import { CacheModule, CacheStore, Module } from '@nestjs/common';
 import { RedisService } from './redis.service';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { redisStore } from 'cache-manager-redis-store';
+import { CacheMiddleware } from './cache.middleware';
 
 // @Global()
 @Module({
@@ -26,6 +27,6 @@ import { redisStore } from 'cache-manager-redis-store';
       isGlobal: true,
     }),
   ],
-  providers: [RedisService],
+  providers: [RedisService, CacheMiddleware],
 })
 export class RedisModule {}

--- a/src/redis/redis.service.ts
+++ b/src/redis/redis.service.ts
@@ -1,10 +1,49 @@
-import { CACHE_MANAGER, Inject, Injectable } from '@nestjs/common';
+import { CACHE_MANAGER, Inject, Injectable, Logger } from '@nestjs/common';
 import { Cache } from 'cache-manager';
 @Injectable()
 export class RedisService {
-  constructor(@Inject(CACHE_MANAGER) private readonly cache: Cache) {}
+  private readonly logger;
 
-  async clearCache() {
+  constructor(@Inject(CACHE_MANAGER) private readonly cache: Cache) {
+    this.logger = new Logger(RedisService.name);
+  }
+
+  async reset() {
+    // this.logger.log('reset():');
     await this.cache.reset();
+  }
+
+  async get(key: string) {
+    // this.logger.log('get():' + key);
+    return await this.cache.get(key);
+  }
+
+  async set(key: string, val: any, ttl?: number) {
+    // this.logger.log('set():' + key);
+    // this.logger.log(val);
+    await this.cache.set(key, val, ttl);
+  }
+
+  async clear(key: string) {
+    // this.logger.log('clear():' + key);
+    await this.cache.del(key);
+  }
+
+  /**
+   *
+   * @param key string
+   * clears the cache based on the regex pattern (key + "*")
+   */
+  async clearAll(key?: string) {
+    // this.logger.log('clearAll():' + key);
+    if (!key || key.length == 0) {
+      return await this.cache.reset();
+    }
+
+    const allKeys: string[] = await this.cache.store.keys(key + '*');
+    for (const i in allKeys) {
+      // this.logger.log(`del: ${allKeys[i]}`);
+      await this.cache.del(allKeys[i]);
+    }
   }
 }

--- a/src/so/so.module.ts
+++ b/src/so/so.module.ts
@@ -1,12 +1,26 @@
-import { Module } from '@nestjs/common';
+import {
+  MiddlewareConsumer,
+  Module,
+  NestModule,
+  RequestMethod,
+} from '@nestjs/common';
 import { SoController } from './so.controller';
 import { SoService } from './so.service';
 import { SoGateway } from './so.gateway';
 import { JwtModule } from '@nestjs/jwt';
+import { CacheMiddleware } from '../redis/cache.middleware';
+import { RedisService } from '../redis/redis.service';
 
 @Module({
   imports: [JwtModule.register({})],
   controllers: [SoController],
-  providers: [SoService, SoGateway],
+  providers: [SoService, SoGateway, RedisService],
 })
-export class SoModule {}
+export class SoModule implements NestModule {
+  configure(consumer: MiddlewareConsumer) {
+    consumer.apply(CacheMiddleware).forRoutes({
+      path: '/*',
+      method: RequestMethod.GET,
+    });
+  }
+}

--- a/src/so/so.service.ts
+++ b/src/so/so.service.ts
@@ -44,7 +44,7 @@ export class SoService {
     });
   }
 
-  async getSoById(soId: number) {
+  async getSoById(soId: number, params?: PaginationParams) {
     try {
       return await this.prisma.so.findFirstOrThrow({
         where: {
@@ -55,6 +55,7 @@ export class SoService {
           content: true,
           tag: true,
         },
+        ...params,
       });
     } catch (error) {
       throw new NotFoundException('so does not exist!');
@@ -148,32 +149,5 @@ export class SoService {
         userId,
       },
     });
-  }
-
-  filterQueryParams(query: string): PaginationParams {
-    const params: PaginationParams = {
-      orderBy: {},
-    };
-    if (query['skip']) {
-      try {
-        params['skip'] = parseInt(query['skip']);
-      } catch (error) {}
-    }
-    if (query['take']) {
-      try {
-        params['take'] = parseInt(query['take']);
-      } catch (error) {}
-    }
-
-    if (
-      query['orderby'] === 'id' ||
-      query['orderby'] === 'userId' ||
-      query['orderby'] === 'tag'
-    ) {
-      const type: string = query['type'] === 'desc' ? 'desc' : 'asc';
-      params['orderBy'][query['orderby']] = type;
-    }
-
-    return params;
   }
 }

--- a/src/user/user.module.ts
+++ b/src/user/user.module.ts
@@ -1,9 +1,18 @@
-import { Module } from '@nestjs/common';
+import { MiddlewareConsumer, Module, RequestMethod } from '@nestjs/common';
 import { UserController } from './user.controller';
 import { UserService } from './user.service';
+import { RedisService } from '../redis/redis.service';
+import { CacheMiddleware } from '../redis/cache.middleware';
 
 @Module({
   controllers: [UserController],
-  providers: [UserService],
+  providers: [UserService, RedisService],
 })
-export class UserModule {}
+export class UserModule {
+  configure(consumer: MiddlewareConsumer) {
+    consumer.apply(CacheMiddleware).forRoutes({
+      path: '/users',
+      method: RequestMethod.GET,
+    });
+  }
+}

--- a/src/util/cacheKeyParser.ts
+++ b/src/util/cacheKeyParser.ts
@@ -1,0 +1,46 @@
+import { PaginationParams } from '../../types';
+/**
+ *
+ * @param url the url string
+ * @param params valid pagination parameter object
+ * @returns a valid cache key
+ *
+ * combine the url & valid parsed pagination params to form a redis key
+ */
+export function cacheKeyCreator(
+  url: string,
+  params?: PaginationParams,
+): string {
+  // parse /path/ => /path
+  // /path => /path (remains same)
+  let cacheKey: string;
+
+  if (!url || url.length == 0) {
+    cacheKey = 'so';
+  } else if (url.lastIndexOf('/') == url.length - 1) {
+    cacheKey = url.substring(0, url.length - 1);
+  } else {
+    cacheKey = url;
+  }
+
+  if (!params) {
+    return cacheKey; // incase there are no parameters
+  }
+
+  if (params['skip']) {
+    cacheKey += '-skip=';
+    cacheKey += params['skip'];
+  }
+  if (params['take']) {
+    cacheKey += '-take=';
+    cacheKey += params['take'];
+  }
+  for (const j in params['orderBy']) {
+    cacheKey += '-orderby=';
+    cacheKey += j;
+    cacheKey += '-type=';
+    cacheKey += params['orderBy'][j];
+  }
+
+  return cacheKey;
+}

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -1,0 +1,3 @@
+export * from './parseQueryParams';
+export * from './cacheKeyParser';
+export * from './redirect.interceptor';

--- a/src/util/parseQueryParams.ts
+++ b/src/util/parseQueryParams.ts
@@ -1,0 +1,33 @@
+import { PaginationParams } from '../../types';
+
+/**
+ *
+ * @param query contains a query object with fields {skip, take, orderby, type}
+ * @returns PaginationParams
+ */
+export function parseQueryParams(query: string): PaginationParams {
+  const params: PaginationParams = {
+    orderBy: {},
+  };
+  if (query['skip']) {
+    try {
+      params['skip'] = parseInt(query['skip']);
+    } catch (error) {}
+  }
+  if (query['take']) {
+    try {
+      params['take'] = parseInt(query['take']);
+    } catch (error) {}
+  }
+
+  if (
+    query['orderby'] === 'id' ||
+    query['orderby'] === 'userId' ||
+    query['orderby'] === 'tag'
+  ) {
+    const type: string = query['type'] === 'desc' ? 'desc' : 'asc';
+    params['orderBy'][query['orderby']] = type;
+  }
+
+  return params;
+}

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -33,7 +33,7 @@ describe('So Test e2e:', () => {
     prisma = app.get(PrismaService);
     await prisma.cleanDb(); // reset DB
     redis = app.get(RedisService);
-    await redis.clearCache();
+    await redis.reset();
     pactum.request.setBaseUrl('http://localhost:' + PORT); // pactum config
   });
 


### PR DESCRIPTION
Why?
- initially, the caching is using the default caching interceptors which provide a good general use, but there are more cache miss in that strategy since the caching keys are created dynamically using the routes
- the code looked more generic and lot of inconsistency in code

How?
- created a caching middleware that  works on GET routes 
- dynamically computes keys using some predefined logic
- performs a cache lookup
- returns with the result if cache hit
- forwards the control to the controller is cache miss
- on POST, PATCH, DELETE requests, the respective cache keys are cleared

Benefits:
- less cache miss
- better and more sensible keys (can be manually used using redis-cli)
- more consistent code
- more readable code
- less automagic in code and easier to understand for beginners